### PR TITLE
Dynamic redNAND support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ patched_sections/*.bin
 
 # IOS img
 bin/*.bin
+core.ipx

--- a/wafel_core/source/addrs_55x.h
+++ b/wafel_core/source/addrs_55x.h
@@ -23,9 +23,6 @@
 // fatfs size to use (mb) is ((NUM_SECTORS - MLC_SIZE - 0x200800) / 0x800) - 1
 // OFFS_SECTORS is count subtracted from num_sectors
 #define USB_OFFS_SECTORS (0) // unused atm
-#define MLC_OFFS_SECTORS (SLC_OFFS_SECTORS + MLC_SIZE)      // sectors at NUM_SECTORS-0x03C20000
-#define SLC_OFFS_SECTORS (SLCCMPT_OFFS_SECTORS + 0x100000)  // sectors at NUM_SECTORS-0x00200000
-#define SLCCMPT_OFFS_SECTORS (0x100000)                     // sectors at NUM_SECTORS-0x00100000
 
 #define FS_MMC_SDCARD_STRUCT (0x1089B9F8)
 #define FS_MMC_MLC_STRUCT (0x1089B948)

--- a/wafel_core/source/config.h
+++ b/wafel_core/source/config.h
@@ -15,7 +15,7 @@
 // Filesystem config
 // *****************************
 // Enable NAND redirection (use minute to prepare your SD card)
-#define USE_REDNAND 0
+#define USE_REDNAND 1
 
 // Enable MLC only redirection (uses same SD layout as REDNAND)
 #define USE_REDMLC 0

--- a/wafel_core/source/config.h
+++ b/wafel_core/source/config.h
@@ -38,15 +38,6 @@
 // Disables the disk drive by overriding the SEEPROM configuration to 0x0002 (None)
 #define DISABLE_DISK_DRIVE 0
 
-// Dramatically accelerate emulated MLC speed by moving the MLC cache from SLC (on SD)
-// to compat-SLC (on system, when USE_SYS_SLCCMPT is set).
-// This removes significant bottlenecks from MLC I/O and reduces wear on the SD card.
-// This will use just over 128MB of free space on vWii NAND.
-//
-// BACK UP YOUR REDNAND BEFORE ENABLING THIS! The migration process is stable and safe
-// but is inherently dangerous.
-#define MLC_ACCELERATE 0
-
 // This setting enables a number of features for (manually selected) USB disks.
 // In short: The beginning of the WiiU-formatted data on disk will begin 1MB in
 // instead of at sector 0, the size of the partition can be set, and all disk 

--- a/wafel_core/source/config.h
+++ b/wafel_core/source/config.h
@@ -38,6 +38,15 @@
 // Disables the disk drive by overriding the SEEPROM configuration to 0x0002 (None)
 #define DISABLE_DISK_DRIVE 0
 
+// Dramatically accelerate emulated MLC speed by moving the MLC cache from SLC (on SD)
+// to compat-SLC (on system, when USE_SYS_SLCCMPT is set).
+// This removes significant bottlenecks from MLC I/O and reduces wear on the SD card.
+// This will use just over 128MB of free space on vWii NAND.
+//
+// BACK UP YOUR REDNAND BEFORE ENABLING THIS! The migration process is stable and safe
+// but is inherently dangerous.
+#define MLC_ACCELERATE 0
+
 // This setting enables a number of features for (manually selected) USB disks.
 // In short: The beginning of the WiiU-formatted data on disk will begin 1MB in
 // instead of at sector 0, the size of the partition can be set, and all disk 

--- a/wafel_core/source/config.h
+++ b/wafel_core/source/config.h
@@ -17,14 +17,6 @@
 // Enable NAND redirection (use minute to prepare your SD card)
 #define USE_REDNAND 1
 
-// Enable MLC only redirection (uses same SD layout as REDNAND)
-#define USE_REDMLC 0
-
-// Disables block level MLC cache on SLC
-// Only enable this if you rebuild the MLC or use a MLC Backup created by FSA (not minute, not the nand dumper)
-// Toggeling this option on an existing MLC will damage the filesystem
-#define DISABLE_SCFM 0
-
 // OTP does not exist, and should be loaded from memory instead
 #define OTP_IN_MEM 1
 
@@ -45,10 +37,6 @@
 
 // Disables the disk drive by overriding the SEEPROM configuration to 0x0002 (None)
 #define DISABLE_DISK_DRIVE 0
-
-// Use sysnand vWii slc instead of redirecting it to the SD card.
-// This allows vWii and eShop Wii games to boot, and is basically 100% safe.
-#define USE_SYS_SLCCMPT 1
 
 // Dramatically accelerate emulated MLC speed by moving the MLC cache from SLC (on SD)
 // to compat-SLC (on system, when USE_SYS_SLCCMPT is set).
@@ -118,21 +106,5 @@
 // dump current syslog contents to SYSLOG_OFFS_SECTORS on every FSA log write.
 // (debugging feature, will cause slowdown and hammer on the SD card)
 #define DUMP_LOG 0
-
-// sanity-check some config things
-#if MLC_ACCELERATE & !USE_SYS_SLCCMPT
-#error "MLC_ACCELERATE is only supported with USE_SYS_SLCCMPT enabled!!"
-#endif
-#if MLC_ACCELERATE & !USE_REDNAND & !USE_REDMLC
-#error "MLC_ACCELERATE on sysnand will brick on reboot without bootloader hax!!"
-#endif
-
-#if DISABLE_SCFM & !USE_REDNAND & !USE_REDMLC
-#error "MLC_ACCELERATE on sysnand will brick on reboot without bootloader hax!!"
-#endif
-
-#if USE_REDMLC & !DISABLE_SCFM & !MLC_ACCELERATE
-#error "Using REDMLC with the SCFM on SLC will corrupt your system MLC!!"
-#endif
 
 #endif // _CONFIG_H

--- a/wafel_core/source/config.h
+++ b/wafel_core/source/config.h
@@ -46,15 +46,6 @@
 // Disables the disk drive by overriding the SEEPROM configuration to 0x0002 (None)
 #define DISABLE_DISK_DRIVE 0
 
-// Set the size of mlc storage, in sectors 
-// (TODO: autoconfig for this! we need to support arbitrary sizes anyway)
-#define MLC_SIZE (0x03A20000) // 32GB
-//#define MLC_SIZE (0x00E50000) // 8GB
-//#define MLC_SIZE (0x2B760000) //373GB
-
-// Override MLC size in IOSU
-#define OVERRIDE_MLC_SIZE 0
-
 // Use sysnand vWii slc instead of redirecting it to the SD card.
 // This allows vWii and eShop Wii games to boot, and is basically 100% safe.
 #define USE_SYS_SLCCMPT 1

--- a/wafel_core/source/ios/prsh.c
+++ b/wafel_core/source/ios/prsh.c
@@ -68,6 +68,12 @@ void prsh_init(void)
 
     initialized = true;
 
+    for (int i = 0; i < header->entries; i++)
+    {
+        prsh_entry* entry = &header->entry[i];
+        debug_printf("%02x: %s\n", i, entry->name);
+    }
+
     // TODO: verify checksums
 }
 

--- a/wafel_core/source/main.c
+++ b/wafel_core/source/main.c
@@ -374,6 +374,7 @@ static void init_config()
     if(ret >= 0){
         redmlc_off_sectors = partition[0];
         redmlc_size_sectors = partition[1];
+        debug_printf("redmlc start: %u size: %u\n", redmlc_off_sectors, redmlc_size_sectors);
         if(redmlc_size_sectors)
             redmlc = true;
     }
@@ -381,6 +382,7 @@ static void init_config()
     ret = prsh_get_entry("redslc", (void**) &partition, &d_size);
     if(ret >= 0){
         redslc_off_sectors = partition[0];
+        debug_printf("redslc start: %u size: %u\n", redslc_off_sectors, partition[1]);
         if(partition[1])
             redslc = true;
     }
@@ -388,6 +390,7 @@ static void init_config()
     ret = prsh_get_entry("redslccmpt", (void**) &partition, &d_size);
     if(ret >= 0){
         redslccmpt_off_sectors = partition[0];
+        debug_printf("redslccmpt start: %u size: %u\n", redslccmpt_off_sectors, partition[1]);
         if(partition[1])
             redslccmpt = true;
     }
@@ -900,6 +903,7 @@ static void patch_55x()
 
 #if DISABLE_SCFM | USE_REDNAND
         if(DISABLE_SCFM && disable_scfm){
+            printf("Disableing SCFM\n");
             ASM_PATCH_K(0x107d1f28, "nop\n");
             ASM_PATCH_K(0x107d1e08,"nop\n");
             ASM_PATCH_K(0x107e7628,"mov r3, #0x0\nstr r3, [r10]\n");
@@ -915,6 +919,7 @@ static void patch_55x()
         );
 
         u32 mlc_size = USE_REDNAND && redmlc ? redmlc_size_sectors : MLC_SIZE;
+        printf("Setting mlc size to: %u LBAs\n", mlc_size);
         U32_PATCH_K(0x107bdbdc, mlc_size + 0xFFFF);
 #endif
     }

--- a/wafel_core/source/main.c
+++ b/wafel_core/source/main.c
@@ -61,9 +61,10 @@ u32 redslccmpt_off_sectors;
 
 u32 redmlc_size_sectors = 0;
 bool redmlc = false;
-bool redslc = false;
-bool redslccmpt = false;
 bool disable_scfm = false;
+u32 redslc = false; //u32, because used in asm
+u32 redslccmpt = false;
+
 
 #define rednand (redmlc || redslc || redslccmpt)
 
@@ -389,13 +390,15 @@ static void init_config()
             redslc = true;
     }
 
-    ret = prsh_get_entry("redslccmpt", (void**) &partition, &d_size);
-    if(ret >= 0){
-        redslccmpt_off_sectors = partition[0];
-        debug_printf("redslccmpt start: %u size: %u\n", redslccmpt_off_sectors, partition[1]);
-        if(partition[1])
-            redslccmpt = true;
-    }
+    #if !USE_SYS_SLCCMPT
+        ret = prsh_get_entry("redslccmpt", (void**) &partition, &d_size);
+        if(ret >= 0){
+            redslccmpt_off_sectors = partition[0];
+            debug_printf("redslccmpt start: %u size: %u\n", redslccmpt_off_sectors, partition[1]);
+            if(partition[1])
+                redslccmpt = true;
+        }
+    #endif
 
     #if USE_REDNAND
         if(redmlc && !redslc)

--- a/wafel_core/source/main.c
+++ b/wafel_core/source/main.c
@@ -964,6 +964,8 @@ void kern_main()
     init_heap();
     init_phdrs();
     init_linking();
+    // Read config.ini from PRSH memory
+    init_config();
 
     // TODO verify the bytes that are overwritten?
     // and/or search for instructions where critical (OTP)
@@ -982,9 +984,6 @@ void kern_main()
 
     // Make sure bss and such doesn't get initted again.
     //ASM_PATCH_K(kern_entry, "bx lr");
-
-    // Read config.ini from PRSH memory
-    init_config();
 
     call_plugin_entry("kern_entry");
 

--- a/wafel_core/source/main.c
+++ b/wafel_core/source/main.c
@@ -375,8 +375,10 @@ static void init_config()
     }
 
     rednand_config *rednand_conf = NULL;
-    ret = prsh_get_entry("redmlc", (void**) rednand_conf, &d_size);
+    ret = prsh_get_entry("rednand", (void**) &rednand_conf, &d_size);
     if(ret >= 0 && rednand_conf->initilized){
+        debug_printf("Found redNAND config\n");
+
         redslc_off_sectors = rednand_conf->slc.lba_start;
         redslc_size_sectors = rednand_conf->slc.lba_length;
         

--- a/wafel_core/source/main.c
+++ b/wafel_core/source/main.c
@@ -904,7 +904,7 @@ static void patch_55x()
         ASM_PATCH_K(0x107e7628,"mov r3, #0x0\nstr r3, [r10]\n");
 #endif
 
-#if OVERRIDE_MLC_SIZE
+#if OVERRIDE_MLC_SIZE | USE_REDNAND
 ASM_PATCH_K(0x107bdb10,
           "nop\n"
           "nop\n"
@@ -912,7 +912,9 @@ ASM_PATCH_K(0x107bdb10,
           "ldr r4, [pc, #0xb8]\n"
         );
 
-U32_PATCH_K(0x107bdbdc, MLC_SIZE + 0xFFFF);
+u32 mlc_size = USE_REDNAND && redmlc ? redmlc_size_sectors : MLC_SIZE;
+
+U32_PATCH_K(0x107bdbdc, mlc_size + 0xFFFF);
 #endif
     }
 }

--- a/wafel_core/source/main.c
+++ b/wafel_core/source/main.c
@@ -898,23 +898,24 @@ static void patch_55x()
         BL_TRAMPOLINE_K(0x107E7B88, FS_ALTBASE_ADDR(scfm_try_slc_cache_migration));
 #endif
 
-#if DISABLE_SCFM
-        ASM_PATCH_K(0x107d1f28, "nop\n");
-        ASM_PATCH_K(0x107d1e08,"nop\n");
-        ASM_PATCH_K(0x107e7628,"mov r3, #0x0\nstr r3, [r10]\n");
+#if DISABLE_SCFM | USE_REDNAND
+        if(DISABLE_SCFM && disable_scfm){
+            ASM_PATCH_K(0x107d1f28, "nop\n");
+            ASM_PATCH_K(0x107d1e08,"nop\n");
+            ASM_PATCH_K(0x107e7628,"mov r3, #0x0\nstr r3, [r10]\n");
+        }
 #endif
 
 #if OVERRIDE_MLC_SIZE | USE_REDNAND
-ASM_PATCH_K(0x107bdb10,
+        ASM_PATCH_K(0x107bdb10,
           "nop\n"
           "nop\n"
           "nop\n"
           "ldr r4, [pc, #0xb8]\n"
         );
 
-u32 mlc_size = USE_REDNAND && redmlc ? redmlc_size_sectors : MLC_SIZE;
-
-U32_PATCH_K(0x107bdbdc, mlc_size + 0xFFFF);
+        u32 mlc_size = USE_REDNAND && redmlc ? redmlc_size_sectors : MLC_SIZE;
+        U32_PATCH_K(0x107bdbdc, mlc_size + 0xFFFF);
 #endif
     }
 }

--- a/wafel_core/source/main.c
+++ b/wafel_core/source/main.c
@@ -826,6 +826,8 @@ static void patch_55x()
         // (nulling them out is apparently ok; more importantly, i'm not sure what they do and would rather get a crash than unwanted slc-writing)
 #if USE_REDNAND
         if(redslc_size_sectors || redslccmpt_size_sectors){
+            debug_printf("Enabeling SLC/SLCCMPT redirection\n");
+
             U32_PATCH_K(0x107B96B8, 0);
             U32_PATCH_K(0x107B96BC, 0);
 
@@ -840,6 +842,7 @@ static void patch_55x()
 #endif // USE_REDNAND
 #if USE_REDNAND
         if(redmlc_size_sectors){
+            debug_printf("Enabeling MLC redirection\n");
             // mlc redirection
             BRANCH_PATCH_K(FS_SDCARD_READ1, FS_ALTBASE_ADDR(sdcardRead_patch));
             BRANCH_PATCH_K(FS_SDCARD_WRITE1, FS_ALTBASE_ADDR(sdcardWrite_patch));
@@ -926,7 +929,7 @@ static void patch_55x()
             "ldr r4, [pc, #0xb8]\n"
             );
 
-            printf("Setting mlc size to: %u LBAs\n", redmlc_size_sectors);
+            debug_printf("Setting mlc size to: %u LBAs\n", redmlc_size_sectors);
             U32_PATCH_K(0x107bdbdc, redmlc_size_sectors + 0xFFFF);
         }
 #endif

--- a/wafel_core/source/main.c
+++ b/wafel_core/source/main.c
@@ -889,6 +889,7 @@ static void patch_55x()
         BL_TRAMPOLINE_K(0x1070A46C, FS_ALTBASE_ADDR(seekfile_hook));
 #endif // PRINT_FSASEEKFILE
 
+        if(scfm_on_slccmpt){
 #if MLC_ACCELERATE
         // hooks for supporting scfm.img on sys-slccmpt instead of on the sd card
         // e.g. doing sd->slc caching instead of sd->sd caching which dramatically slows down ALL i/o
@@ -900,7 +901,12 @@ static void patch_55x()
     
         //hook scfmInit right after fsa initialization, before main thread creation
         BL_TRAMPOLINE_K(0x107E7B88, FS_ALTBASE_ADDR(scfm_try_slc_cache_migration));
+#else
+        const char* panic = "BUIDL without MLC_ACCELERATE\n";
+        iosPanic(panic, strlen(panic)+1);
+        while(1);
 #endif
+        }
 
 #if USE_REDNAND
         if(disable_scfm){

--- a/wafel_core/source/main.c
+++ b/wafel_core/source/main.c
@@ -65,14 +65,6 @@ u32 redslc_size_sectors = 0;
 u32 redslccmpt_size_sectors = 0;
 
 bool disable_scfm = false;
-
-// Dramatically accelerate emulated MLC speed by moving the MLC cache from SLC (on SD)
-// to compat-SLC (on system, when USE_SYS_SLCCMPT is set).
-// This removes significant bottlenecks from MLC I/O and reduces wear on the SD card.
-// This will use just over 128MB of free space on vWii NAND.
-//
-// BACK UP YOUR REDNAND BEFORE ENABLING THIS! The migration process is stable and safe
-// but is inherently dangerous.
 bool scfm_on_slccmpt = false;
 
 
@@ -897,7 +889,7 @@ static void patch_55x()
         BL_TRAMPOLINE_K(0x1070A46C, FS_ALTBASE_ADDR(seekfile_hook));
 #endif // PRINT_FSASEEKFILE
 
-    if(scfm_on_slccmpt){
+#if MLC_ACCELERATE
         // hooks for supporting scfm.img on sys-slccmpt instead of on the sd card
         // e.g. doing sd->slc caching instead of sd->sd caching which dramatically slows down ALL i/o
         
@@ -908,7 +900,7 @@ static void patch_55x()
     
         //hook scfmInit right after fsa initialization, before main thread creation
         BL_TRAMPOLINE_K(0x107E7B88, FS_ALTBASE_ADDR(scfm_try_slc_cache_migration));
-    }
+#endif
 
 #if USE_REDNAND
         if(disable_scfm){

--- a/wafel_core/source/patch_asm.S
+++ b/wafel_core/source/patch_asm.S
@@ -969,7 +969,7 @@ ios_ledout:
 
 @ our own custom code starts here
 
-#if USE_REDNAND
+#if MLC_ACCELERATE
 
 .align 4
 scfm_try_slc_cache_migration:

--- a/wafel_core/source/patch_asm.S
+++ b/wafel_core/source/patch_asm.S
@@ -969,7 +969,7 @@ ios_ledout:
 
 @ our own custom code starts here
 
-#if MLC_ACCELERATE
+#if USE_REDNAND
 
 .align 4
 scfm_try_slc_cache_migration:

--- a/wafel_core/source/patch_asm.S
+++ b/wafel_core/source/patch_asm.S
@@ -1435,19 +1435,6 @@ sdcard_init:
     ldr r1, [r0, #0x28]
     bic r1, #0x4
     str r1, [r0, #0x28]
-    
-    @ set sdcard size for emu hooks
-    ldr r1, [r0, #0x30]
-    mov r0, #0
-    sub r0, #0x10000
-    and r1, r0  @ sdcard_size &= 0xFFFF0000
-    ldr r0, =sdcard_num_sectors
-    str r1, [r0]
-
-    @ TODO: spoof MLC sector count for resized emunand (this patch is ready)
-    @ ldr r0, =FS_MMC_MLC_STRUCT
-    @ ldr r1, =MLC_SIZE
-    @ str r1, [r0, #0x30]
 
     pop {pc}
 
@@ -1778,10 +1765,8 @@ sdcardReadWrite_patch:
     cmp r2, #6 @ DEVICETYPE_SDCARD
     moveq r1, #0
     beq sdcardReadWrite_patch_cont
-    ldr r2, =MLC_OFFS_SECTORS @ mlc
-    ldr r1, =sdcard_num_sectors
+    ldr r1, =redmlc_off_sectors
     ldr r1, [r1]
-    sub r1, r2
     
 sdcardReadWrite_patch_cont:
     pop {r2}
@@ -1804,12 +1789,10 @@ slcReadWrite_patch:
     ldr r2, [r0, #4]
     mov r0, r1
     cmp r2, #0
-    ldrne r2, =SLC_OFFS_SECTORS
-    ldreq r2, =SLCCMPT_OFFS_SECTORS
-    ldr r1, =sdcard_num_sectors
+    ldrne r1, =redslc_off_sectors
+    ldreq r1, =redslccmpt_off_sectors
     ldr r1, [r1]
     
-    sub r1, r2
     lsr r1, #2   @ 4 sd sectors -> 1 slc sector
     pop {r2}
     b readWriteCallback_patch
@@ -2051,10 +2034,16 @@ drawCharacter:
 
 .pool
 
+.section ".extern"
+redmlc_off_sectors:
+    .word 0
+redslc_off_sectors:
+    .word 0
+redslccmpt_off_sectors:
+    .word 0
+
 .section ".bss"
 
-sdcard_num_sectors:
-    .word 0x00000000
 sdcard_access_mutex:
     .word 0x00000000
 mlc_out_callback_arg2:

--- a/wafel_core/source/patch_asm.S
+++ b/wafel_core/source/patch_asm.S
@@ -18,6 +18,8 @@
 .extern redmlc_off_sectors
 .extern redslc_off_sectors
 .extern redslccmpt_off_sectors
+.extern redslc
+.extern redslccmpt
 
 .globl otp_read_replace_hacky
 .globl otp_read_replace_hacky_end
@@ -1802,9 +1804,12 @@ slcReadWrite_patch:
     b readWriteCallback_patch
 
 slcRead1_patch:
-#if USE_SYS_SLCCMPT
     push {r0, r1}
     ldr r1, [r0, #4]
+    cmp r1, #0
+    ldrne r1, =redslc
+    ldreq r1, =redslccmpt
+    ldr r1, [r1]
     cmp r1, #0
     pop {r0, r1}
     bne slcRead1_patch_cont
@@ -1813,15 +1818,17 @@ slcRead1_patch:
     stmfd sp!, {r4-r8,lr}
     b REL_FS_SLC_READ1+4
     
-#endif
 slcRead1_patch_cont:
     mov r1, #1 @ read
     b slcReadWrite_patch
 
 slcWrite1_patch:
-#if USE_SYS_SLCCMPT
     push {r0, r1}
     ldr r1, [r0, #4]
+    cmp r1, #0
+    ldrne r1, =redslc
+    ldreq r1, =redslccmpt
+    ldr r1, [r1]
     cmp r1, #0
     pop {r0, r1}
     bne slcWrite1_patch_cont
@@ -1829,15 +1836,18 @@ slcWrite1_patch:
     @ slccmpt, do replaced instruction and return to use syscmpt
     stmfd sp!, {r4-r8,lr}
     b REL_FS_SLC_WRITE1+4
-#endif
+
 slcWrite1_patch_cont:
     mov r1, #0 @ write
     b slcReadWrite_patch
 
 slcRead2_patch:
-#if USE_SYS_SLCCMPT
     push {r0, r1}
     ldr r1, [r0, #4]
+    cmp r1, #0
+    ldrne r1, =redslc
+    ldreq r1, =redslccmpt
+    ldr r1, [r1]
     cmp r1, #0
     pop {r0, r1}
     bne slcRead2_patch_cont
@@ -1845,7 +1855,7 @@ slcRead2_patch:
     @ slccmpt, do replaced instruction and return to use syscmpt
     stmfd sp!, {r4-r8,lr}
     b REL_FS_SLC_READ2+4
-#endif
+
 slcRead2_patch_cont:
 .equ slcRead2_patch_stackframe_size, (0x10+7*4)
     push {r0-r5,lr}
@@ -1864,9 +1874,12 @@ slcRead2_patch_cont:
 
     
 slcWrite2_patch:
-#if USE_SYS_SLCCMPT
     push {r0, r1}
     ldr r1, [r0, #4]
+    cmp r1, #0
+    ldrne r1, =redslc
+    ldreq r1, =redslccmpt
+    ldr r1, [r1]
     cmp r1, #0
     pop {r0, r1}
     bne slcWrite2_patch_cont
@@ -1874,7 +1887,7 @@ slcWrite2_patch:
     @ slccmpt, do replaced instruction and return to use syscmpt
     stmfd sp!, {r4-r8,lr}
     b REL_FS_SLC_WRITE2+4
-#endif
+
 slcWrite2_patch_cont:
 .equ slcWrite2_patch_stackframe_size, (0x10+6*4)
     push {r0-r4,lr}

--- a/wafel_core/source/patch_asm.S
+++ b/wafel_core/source/patch_asm.S
@@ -18,8 +18,8 @@
 .extern redmlc_off_sectors
 .extern redslc_off_sectors
 .extern redslccmpt_off_sectors
-.extern redslc
-.extern redslccmpt
+.extern redslc_size_sectors
+.extern redslccmpt_size_sectors
 
 .globl otp_read_replace_hacky
 .globl otp_read_replace_hacky_end
@@ -1807,8 +1807,8 @@ slcRead1_patch:
     push {r0, r1}
     ldr r1, [r0, #4]
     cmp r1, #0
-    ldrne r1, =redslc
-    ldreq r1, =redslccmpt
+    ldrne r1, =redslc_size_sectors
+    ldreq r1, =redslccmpt_size_sectors
     ldr r1, [r1]
     cmp r1, #0
     pop {r0, r1}
@@ -1826,8 +1826,8 @@ slcWrite1_patch:
     push {r0, r1}
     ldr r1, [r0, #4]
     cmp r1, #0
-    ldrne r1, =redslc
-    ldreq r1, =redslccmpt
+    ldrne r1, =redslc_size_sectors
+    ldreq r1, =redslccmpt_size_sectors
     ldr r1, [r1]
     cmp r1, #0
     pop {r0, r1}
@@ -1845,8 +1845,8 @@ slcRead2_patch:
     push {r0, r1}
     ldr r1, [r0, #4]
     cmp r1, #0
-    ldrne r1, =redslc
-    ldreq r1, =redslccmpt
+    ldrne r1, =redslc_size_sectors
+    ldreq r1, =redslccmpt_size_sectors
     ldr r1, [r1]
     cmp r1, #0
     pop {r0, r1}
@@ -1877,8 +1877,8 @@ slcWrite2_patch:
     push {r0, r1}
     ldr r1, [r0, #4]
     cmp r1, #0
-    ldrne r1, =redslc
-    ldreq r1, =redslccmpt
+    ldrne r1, =redslc_size_sectors
+    ldreq r1, =redslccmpt_size_sectors
     ldr r1, [r1]
     cmp r1, #0
     pop {r0, r1}

--- a/wafel_core/source/patch_asm.S
+++ b/wafel_core/source/patch_asm.S
@@ -1048,8 +1048,8 @@ scfm_migrate_cmpt_exists:
     mov r0, #0x20 @ nocrypto flag
     str r0, [sp, #8]
     mov r0, r4  @ fsa handle
-    add r1, sp, 0xC  @ buf
-    mov r2, 1   @ size
+    add r1, sp, #0xC  @ buf
+    mov r2, #1  @ size
     mov r3, #4  @ count
     bl REL_FS_FSAREADFILEOFFSET
     mov r6, r0
@@ -1140,7 +1140,7 @@ scfm_migrate_copy_loop:
     str r0, [sp, #8]
     mov r0, r4  @ fsa handle
     mov r1, r7  @ buf
-    mov r2, 1   @ size
+    mov r2, #1  @ size
     mov r3, r9  @ count
     bl REL_FS_FSAREADFILEOFFSET
     cmp r0, r9
@@ -1154,7 +1154,7 @@ scfm_migrate_copy_loop:
     str r0, [sp, #8]
     mov r0, r4  @ fsa handle
     mov r1, r7  @ buf
-    mov r2, 1   @ size
+    mov r2, #1  @ size
     mov r3, r9  @ count
     bl REL_FS_FSAWRITEFILEOFFSET
     cmp r0, r9
@@ -1263,7 +1263,10 @@ scfm_migration_strcpy_loop:
     cmp r3, #0
     bne scfm_migration_strcpy_loop
     bx lr
-str_migration_fail_format: .ascii 0xA,"SCFM-SALT: migration failed, %02d-%08X"
+
+str_migration_fail_format: 
+.byte 0xA
+.ascii "SCFM-SALT: migration failed, %02d-%08X"
 .byte 0xA,0
 str_migrate_progress_format: 
     .ascii "SCFM-SALT: Migrating scfm.img, %d bytes remaining..."

--- a/wafel_core/source/patch_asm.S
+++ b/wafel_core/source/patch_asm.S
@@ -15,6 +15,10 @@
 
 .extern otp_store
 
+.extern redmlc_off_sectors
+.extern redslc_off_sectors
+.extern redslccmpt_off_sectors
+
 .globl otp_read_replace_hacky
 .globl otp_read_replace_hacky_end
 otp_read_replace_hacky:
@@ -2033,14 +2037,6 @@ drawCharacter:
     pop {r4-r7,pc}
 
 .pool
-
-.section ".extern"
-redmlc_off_sectors:
-    .word 0
-redslc_off_sectors:
-    .word 0
-redslccmpt_off_sectors:
-    .word 0
 
 .section ".bss"
 

--- a/wafel_core/source/rednand_config.h
+++ b/wafel_core/source/rednand_config.h
@@ -1,0 +1,16 @@
+#include "types.h"
+
+typedef struct {
+    u32 lba_start;
+    u32 lba_length;
+} PACKED rednand_partition;
+
+typedef struct {
+    rednand_partition slc;
+    rednand_partition slccmpt;
+    rednand_partition mlc;
+    bool disable_scfm;
+    bool scfm_on_slccmpt;
+    bool initilized;
+} PACKED rednand_config;
+


### PR DESCRIPTION
Honors the redNAND config passed by minute. If no config is passed, doesn't do any redirection